### PR TITLE
Transformations of obstacles corrected for weird lidar orientations

### DIFF
--- a/include/obstacle_detector/utilities/math_utilities.h
+++ b/include/obstacle_detector/utilities/math_utilities.h
@@ -91,6 +91,13 @@ inline Point transformPoint(const Point point, double x, double y, double theta)
   return p;
 }
 
+inline Point transformPoint(const Point& point, const tf::StampedTransform& transform) {
+  tf::Vector3 v(point.x, point.y, 0);
+  v = transform * v;
+
+  return {v.x(), v.y()};
+}
+
 inline bool checkPointInLimits(const geometry_msgs::Point32& p, double x_min, double x_max, double y_min, double y_max) {
   if ((p.x > x_max) || (p.x < x_min) || (p.y > y_max) || (p.y < y_min))
     return false;

--- a/src/obstacle_extractor.cpp
+++ b/src/obstacle_extractor.cpp
@@ -418,16 +418,14 @@ void ObstacleExtractor::publishObstacles() {
       return;
     }
 
-    tf::Vector3 origin = transform.getOrigin();
-    double theta = tf::getYaw(transform.getRotation());
-
+    tf::Vector3 vec;
     for (Segment& s : segments_) {
-      s.first_point = transformPoint(s.first_point, origin.x(), origin.y(), theta);
-      s.last_point = transformPoint(s.last_point, origin.x(), origin.y(), theta);
+      s.first_point = transformPoint(s.first_point, transform);
+      s.last_point = transformPoint(s.last_point, transform);
     }
 
     for (Circle& c : circles_)
-      c.center = transformPoint(c.center, origin.x(), origin.y(), theta);
+      c.center = transformPoint(c.center, transform);
 
     obstacles_msg->header.frame_id = p_frame_id_;
   }

--- a/src/obstacle_extractor.cpp
+++ b/src/obstacle_extractor.cpp
@@ -418,7 +418,6 @@ void ObstacleExtractor::publishObstacles() {
       return;
     }
 
-    tf::Vector3 vec;
     for (Segment& s : segments_) {
       s.first_point = transformPoint(s.first_point, transform);
       s.last_point = transformPoint(s.last_point, transform);


### PR DESCRIPTION
Hi, I found out, while using the **obstacle_extractor** node, that the obstacles generated were not aligned with the laser points, when the lidar (and the TF frame of the scan) was upside down.

I fixed the node so that the points of the segments and circles are fully transformed, instead of just along the yaw axis. That may help some people that have a weird lidar orientation.

The new function `transformPoint` uses `tf::Vector3` and the previously fetched `tf::StampedTransform` to return a transformed `Point`.

The old function that used only the yaw is now unused, but I have not deleted it.

@tysik 