### PR TITLE
modify a miss grouping at start end of laser

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>laser_geometry</depend>
+  <depend>armadillo</depend>
 
   <export>
     <rviz plugin="${prefix}/rviz_plugins.xml"/>

--- a/src/obstacle_extractor.cpp
+++ b/src/obstacle_extractor.cpp
@@ -179,7 +179,7 @@ void ObstacleExtractor::groupPoints() {
   point_set.num_points = 1;
   point_set.is_visible = true;
 
-  for (PointIterator point = input_points_.begin()++; point != input_points_.end(); ++point) {
+  for (PointIterator point = ++input_points_.begin(); point != input_points_.end(); ++point) {
     double range = (*point).length();
     double distance = (*point - *point_set.end).length();
 


### PR DESCRIPTION
It seems that the ```++``` operator is not placed in correct position.