### PR TITLE
Add an explicit dependency to obstacle_detector_generate_messages_cpp.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${ARMADILLO_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
+set(catkin_EXPORTED_TARGETS ${catkin_EXPORTED_TARGETS} obstacle_detector_generate_messages_cpp)
+
 #
 # Build libs
 #


### PR DESCRIPTION
Seems to fix issue #10.

Sometimes, when building with `catkin_make`, we used to get this error:
```
In file included from /home/src/obstacle_detector/src/displays/circle_visual.cpp:36:0:
/home/src/obstacle_detector/include/obstacle_detector/displays/circle_visual.h:39:10: fatal error: obstacle_detector/Obstacles.h: No such file or directory
```
Now our workspace builds with a single catkin_make call.